### PR TITLE
Fix newline bug in last modified hook

### DIFF
--- a/_plugins/posts-lastmod-hook.rb
+++ b/_plugins/posts-lastmod-hook.rb
@@ -7,7 +7,7 @@ Jekyll::Hooks.register :posts, :post_init do |post|
   commit_num = `git rev-list --count HEAD "#{ post.path }"`
 
   if commit_num.to_i > 1
-    lastmod_date = `git log -1 --pretty="%ad" --date=iso "#{ post.path }"`
+    lastmod_date = `git log -1 --pretty="%ad" --date=iso "#{ post.path }"`.strip
     post.data['last_modified_at'] = lastmod_date
   end
 


### PR DESCRIPTION
## Summary
- ensure git log output is stripped

## Testing
- `bash tools/test.sh` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841e8b008188328928b5986da588ec2